### PR TITLE
v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # express-mw-bunyan
 
-express middleware that implements bunyan as a logger
+express middleware that implements bunyan as a logger to be used with `req.log`
 
 <a href="https://nodei.co/npm/express-mw-bunyan/"><img src="https://nodei.co/npm/express-mw-bunyan.png?downloads=true"></a>
 
@@ -12,8 +12,16 @@ express middleware that implements bunyan as a logger
 ### api
 `const logger = require('express-mw-bunyan')`
 
-`app.use(logger(bunyan.createLogger({name: 'api_name'})))`
+```js
+app.use(
+  logger(bunyan.createLogger({name: 'api_name'})),
+  requestHeaderName = 'X-Request-ID'
+)
+```
 
+for more options to configure `bunyan.createLogger` check with [bunyan](https://github.com/trentm/node-bunyan#introduction)
+
+**Note:** should use a middleware like `express-mw-correlation-id` to generate the `req.id` if not `express-mw-bunyan` will generate the `req.id` itself by using `uuid.v4`
 
 ### example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-mw-bunyan",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "express middleware that implements bunyan as a logger",
   "main": "index.js",
   "files": [
@@ -40,7 +40,7 @@
     "express-mw-correlation-id": "^2.0.0",
     "istanbul": "0.4.5",
     "mocha": "^3.2.0",
-    "pre-commit": "^1.1.3",
+    "pre-commit": "^1.2.2",
     "standard": "^8.6.0",
     "supertest": "^2.0.1"
   },
@@ -52,6 +52,7 @@
     "coverage:check"
   ],
   "dependencies": {
-    "set-prop-get-value": "^1.0.0"
+    "set-prop-get-value": "^1.0.0",
+    "uuid.v4": "^1.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -44,7 +44,7 @@ describe('express-mw-bunyan', () => {
     }
   })
 
-  describe('solo', () => {
+  describe('solo use', () => {
 
     before((done) => {
       app = express()


### PR DESCRIPTION
uses `uuid.v4` as the internal correlation/request id