### PR TITLE
Remove payload from default request logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function Logger (bunyan, origin = 'request', headerName = 'X-Request-ID') {
       }
     )
 
-    req.log.info({req: req, payload: req.body}, 'start of the request')
+    req.log.info({req: req}, 'start of the request')
 
     res.on('finish', onFinish)
 


### PR DESCRIPTION
Hello,

Since we can override the default serializers when creating a new logger, we don't need to log the payload by default in the middleware (https://github.com/joaquimserafim/express-mw-bunyan/blob/master/index.js#L31).

What do you think?

Thanks